### PR TITLE
Allow for enums in a function signature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ Use the [Nimble][2] package manager to add `contractabi` to an existing project.
 Add the following to its .nimble file:
 
 ```nim
-requires "contractabi >= 0.4.4 & < 0.5.0"
+requires "contractabi >= 0.4.5 & < 0.5.0"
 ```
 
 Usage

--- a/contractabi.nimble
+++ b/contractabi.nimble
@@ -1,4 +1,4 @@
-version = "0.4.4"
+version = "0.4.5"
 author = "Contract ABI Authors"
 description = "ABI Encoding for Ethereum contracts"
 license = "MIT"

--- a/contractabi/selector.nim
+++ b/contractabi/selector.nim
@@ -37,6 +37,7 @@ solidityType Int256,  "int256"
 solidityType bool,    "bool"
 solidityType string,  "string"
 solidityType Address, "address"
+solidityType enum,    "uint8"
 
 func solidityType*[N: static int, T](_: type array[N, T]): string =
   when T is byte:

--- a/tests/contractabi/testSelector.nim
+++ b/tests/contractabi/testSelector.nim
@@ -4,6 +4,10 @@ import pkg/contractabi
 
 suite "function selector":
 
+  type SomeEnum = enum
+    One
+    Two
+
   test "translates nim types into solidity types":
     check solidityType(uint8) == "uint8"
     check solidityType(uint16) == "uint16"
@@ -29,6 +33,7 @@ suite "function selector":
     check solidityType(array[4, string]) == "string[4]"
     check solidityType(seq[string]) == "string[]"
     check solidityType((Address, string, bool)) == "(address,string,bool)"
+    check solidityType(SomeEnum) == "uint8"
 
   test "calculates solidity function selector":
     check $selector("transfer", (Address, UInt256)) == "0xa9059cbb"


### PR DESCRIPTION
According to [the spec](https://docs.soliditylang.org/en/v0.8.14/abi-spec.html#mapping-solidity-to-abi-types), enums are encoded in a type signature as `uint8`.