### PR TITLE
Support distinct types

### DIFF
--- a/contractabi/decoding.nim
+++ b/contractabi/decoding.nim
@@ -1,3 +1,4 @@
+import std/typetraits
 import pkg/stint
 import pkg/stew/endians2
 import pkg/stew/byteutils
@@ -158,6 +159,9 @@ func decode[I,T](decoder: var AbiDecoder, _: type array[I,T]): ?!array[I,T] =
 
 func decode(decoder: var AbiDecoder, T: type string): ?!T =
   success string.fromBytes(?decoder.read(seq[byte]))
+
+func decode[T: distinct](decoder: var AbiDecoder, _: type T): ?!T =
+  success T(?decoder.read(distinctBase T))
 
 func readOffset(decoder: var AbiDecoder): ?!int =
   let offset = ?decoder.read(uint64)

--- a/contractabi/encoding.nim
+++ b/contractabi/encoding.nim
@@ -1,3 +1,4 @@
+import std/typetraits
 import pkg/stint
 import pkg/upraises
 import pkg/stew/byteutils
@@ -130,6 +131,10 @@ func encode(encoder: var AbiEncoder, tupl: tuple) =
   for element in tupl.fields:
     encoder.write(element)
   encoder.finishTuple()
+
+func encode(encoder: var AbiEncoder, value: distinct) =
+  type Base = distinctBase(typeof(value))
+  encoder.write(Base(value))
 
 func finish(encoder: var AbiEncoder): Tuple =
   doAssert encoder.stack.len == 1, "not all tuples were finished"

--- a/contractabi/selector.nim
+++ b/contractabi/selector.nim
@@ -1,4 +1,5 @@
 import std/strutils
+import std/typetraits
 import pkg/nimcrypto
 import pkg/stint
 import pkg/stew/byteutils
@@ -59,6 +60,9 @@ func solidityType*(Tuple: type tuple): string =
   for parameter in Tuple.default.fields:
     names.add(solidityType(typeof parameter))
   "(" & names.join(",") & ")"
+
+func solidityType*(T: distinct type): string =
+  solidityType(distinctBase T)
 
 func signature*(function: string, Parameters: type tuple = ()): string =
   function & solidityType(Parameters)

--- a/contractabi/selector.nim
+++ b/contractabi/selector.nim
@@ -61,7 +61,7 @@ func solidityType*(Tuple: type tuple): string =
     names.add(solidityType(typeof parameter))
   "(" & names.join(",") & ")"
 
-func solidityType*(T: distinct type): string =
+func solidityType*[T: distinct](_: type T): string =
   solidityType(distinctBase T)
 
 func signature*(function: string, Parameters: type tuple = ()): string =

--- a/tests/contractabi/testDecoding.nim
+++ b/tests/contractabi/testDecoding.nim
@@ -3,6 +3,9 @@ import pkg/questionable/results
 import contractabi
 import ./examples
 
+type SomeDistinctType = distinct uint16
+func `==`*(a, b: SomeDistinctType): bool {.borrow.}
+
 suite "ABI decoding":
 
   proc checkDecode[T](value: T) =
@@ -140,3 +143,6 @@ suite "ABI decoding":
 
   test "decodes strings":
     checkDecode("hello!☺")
+
+  test "decodes distinct types as their base type":
+    checkDecode(SomeDistinctType(0xAABB'u16))

--- a/tests/contractabi/testDecoding.nim
+++ b/tests/contractabi/testDecoding.nim
@@ -4,7 +4,8 @@ import contractabi
 import ./examples
 
 type SomeDistinctType = distinct uint16
-func `==`*(a, b: SomeDistinctType): bool {.borrow.}
+func `==`*(a, b: SomeDistinctType): bool =
+  uint16(a) == uint16(b)
 
 suite "ABI decoding":
 

--- a/tests/contractabi/testEncoding.nim
+++ b/tests/contractabi/testEncoding.nim
@@ -138,6 +138,11 @@ suite "ABI encoding":
   test "encodes strings as UTF-8 byte sequence":
     check AbiEncoder.encode("hello!☺") == AbiEncoder.encode("hello!☺".toBytes)
 
+  test "encodes distinct types as their base type":
+    type SomeDistinctType = distinct uint16
+    let value = 0xAABB'u16
+    check AbiEncoder.encode(SomeDistinctType(value)) == AbiEncoder.encode(value)
+
   test "can determine whether types are dynamic or static":
     check static AbiEncoder.isStatic(uint8)
     check static AbiEncoder.isDynamic(seq[byte])

--- a/tests/contractabi/testSelector.nim
+++ b/tests/contractabi/testSelector.nim
@@ -35,6 +35,10 @@ suite "function selector":
     check solidityType((Address, string, bool)) == "(address,string,bool)"
     check solidityType(SomeEnum) == "uint8"
 
+  test "translates distinct type into base type":
+    type SomeDistinctType = distinct uint16
+    check solidityType(SomeDistinctType) == solidityType(uint16)
+
   test "calculates solidity function selector":
     check $selector("transfer", (Address, UInt256)) == "0xa9059cbb"
     check $selector("transferFrom", (Address, Address, UInt256)) == "0x23b872dd"


### PR DESCRIPTION
Adds default implementations of `solidityType()`, `encode()` and `decode()` for distinct types. They are encoded as their base type by default. The default implementations can be overridden by implementing these functions for the specific distinct type.

Example:

```nim
type SomeDistinctType = distinct uint16

solidityType(SomeDistinctType) # equals "uint16"
AbiEncoder.encode(SomeDistinctType(42'u16)) # encodes as uint16
AbiDecoder.decode(bytes, SomeDistinctType) # decodes as uint16
```