### PR TITLE
chore: remove nim-stew upper bound

### DIFF
--- a/contractabi.nimble
+++ b/contractabi.nimble
@@ -1,10 +1,10 @@
-version = "0.7.1"
+version = "0.7.2"
 author = "Contract ABI Authors"
 description = "ABI Encoding for Ethereum contracts"
 license = "MIT"
 
 requires "stint >= 0.8.1 & < 0.9.0"
-requires "stew >= 0.2.0 & < 0.3.0"
+requires "stew >= 0.2.0"
 requires "nimcrypto >= 0.6.2 & < 0.7.0"
 requires "questionable >= 0.10.10 & < 0.11.0"
 requires "upraises >= 0.1.0 & < 0.2.0"


### PR DESCRIPTION
This PR removes nim-stew upper bound for 3 reasons:

- [nim-ethers](https://github.com/codex-storage/nim-ethers/actions/runs/15166059496/job/42646187862#step:7:1138) is broken after a new release of nim-stew
- [The documentation says that is not recommanded](https://github.com/status-im/nim-stew#:~:text=An%20upper%20bound%20(stew%20%3E%3D%200.2%20%26%20%3C0.3)%20or%20caret%20versions%20(stew%20%5E0.2)%20may%20be%20used%20but%20it%20is%20not%20recommended%20since%20this%20will%20make%20your%20library%20harder%20to%20compose%20with%20other%20libraries%20that%20depend%20on%20stew)
- Got some feedback that [the project does not follow semver](https://github.com/status-im/nim-json-serialization/pull/106#discussion_r2104291539) 